### PR TITLE
Jquery Dupes

### DIFF
--- a/02 - Web UI Template/CognitiveSearch.UI/Views/Shared/_Layout.cshtml
+++ b/02 - Web UI Template/CognitiveSearch.UI/Views/Shared/_Layout.cshtml
@@ -25,10 +25,8 @@
     </environment>
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/css/navbar.css" asp-append-version="true" />
-    <environment include="Development">
-        <script src="~/lib/jquery/dist/jquery.js"></script>
-        <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.js"></script>
-    </environment>
+    <script src="~/lib/jquery/dist/jquery.js"></script>
+    <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.js"></script>
     <environment exclude="Development">
         <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"
                 asp-fallback-src="~/lib/jquery/dist/jquery.min.js"
@@ -71,8 +69,6 @@
 
     @await Html.PartialAsync("_Footer")
 
-    <script src="~/lib/jquery/dist/jquery.js"></script>
-
     <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
 
     <script type="text/javascript">
@@ -92,8 +88,6 @@
     <script src="~/js/search.js"></script>
     <script src="~/js/site.js"></script>
     <script src="~/js/entityMap.js"></script>
-    <script src="~/lib/jquery/dist/jquery.js"></script>
-    <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.js"></script>
     <script src="~/js/PolygonDrawingTool.js"></script>
 
     <script>


### PR DESCRIPTION
## Purpose
Bug fix: dropzone was not defined on upload page.

## Fix
Removed duplicate jquery references to fix broken dropzone. My understanding is that drop zone must be included after jquery. Ie. Jquery must be included first. Re-including jquery will remove dropzone. I kept the first reference and removed the later ones. 

The autocomplete function is also no longer throwing an error. 

## Testing
Please rerun any testing that was done to ensure this jquery refactor did not cause regressions.