### PR TITLE
Fixed document preview for multiple storage connections.

### DIFF
--- a/02 - Web UI Template/CognitiveSearch.UI/Search/DocumentResult.cs
+++ b/02 - Web UI Template/CognitiveSearch.UI/Search/DocumentResult.cs
@@ -16,6 +16,7 @@ namespace CognitiveSearch.UI
         public IList<SearchResult<Document>> Results { get; set; }
         public int? Count { get; set; }
         public string Token { get; set; }
+        public int StorageIndex { get; set; }        
         public string DecodedPath { get; set; }
         public List<object> Tags { get; set; }
         public string SearchId { get; set; }

--- a/02 - Web UI Template/CognitiveSearch.UI/Search/DocumentSearchClient.cs
+++ b/02 - Web UI Template/CognitiveSearch.UI/Search/DocumentSearchClient.cs
@@ -344,16 +344,16 @@ namespace CognitiveSearch.UI
             }
         }
 
-        private string GetToken(string decodedPath)
+        private string GetToken(string decodedPath, out int storageIndex)
         {
             // Initialize tokens and containers if not already initialized
             GetContainerSasUris();
 
             // Determine which token to use.
             string tokenToUse;
-            if (decodedPath.ToLower().Contains(containerAddresses[1])) { tokenToUse = tokens[1]; }
-            else if (decodedPath.ToLower().Contains(containerAddresses[2])) { tokenToUse = tokens[2]; }
-            else { tokenToUse = tokens[0]; }
+            if (decodedPath.ToLower().Contains(containerAddresses[1])) { tokenToUse = tokens[1]; storageIndex = 1; }
+            else if (decodedPath.ToLower().Contains(containerAddresses[2])) { tokenToUse = tokens[2]; storageIndex = 2; }
+            else { tokenToUse = tokens[0]; storageIndex = 0; }
 
             return tokenToUse;
         }
@@ -411,12 +411,14 @@ namespace CognitiveSearch.UI
                 decodedPath = Base64Decode(id);
             }
 
-            string tokenToUse = GetToken(decodedPath);
+            int storageIndex;
+            string tokenToUse = GetToken(decodedPath, out storageIndex);
 
             var result = new DocumentResult
             {
                 Result = response,
                 Token = tokenToUse,
+                StorageIndex = storageIndex,
                 DecodedPath = decodedPath,
                 IdField = idField,
                 IsPathBase64Encoded = _isPathBase64Encoded

--- a/02 - Web UI Template/CognitiveSearch.UI/wwwroot/js/details.js
+++ b/02 - Web UI Template/CognitiveSearch.UI/wwwroot/js/details.js
@@ -180,7 +180,7 @@ function GetFileHTML(data, result) {
         if (pathLower.includes(".pdf")) {
             var expectedType = encodeURIComponent("application/pdf");
             var encodedFilename = encodeURIComponent(filename);
-            var previewPath = `/preview/${encodedFilename}/${expectedType}`;
+            var previewPath = `/preview/${data.storageIndex}/${encodedFilename}/${expectedType}`;
             fileContainerHTML = `<iframe class="file-container" src="${previewPath}"><p>Your browser does not support iframes.</p></iframe>`;
         }
         else if (pathLower.includes(".txt") || pathLower.includes(".json")) {


### PR DESCRIPTION
## Purpose
Bug Fix:
StorageController was only using the first storage container connection string. This broke the multi-connection-string scenario. Passing along storage index with the document result so we can preview it from the correct data source.